### PR TITLE
Return the splat and require on a module.

### DIFF
--- a/modules/exploits/windows/fileformat/esignal_styletemplate_bof.rb
+++ b/modules/exploits/windows/fileformat/esignal_styletemplate_bof.rb
@@ -1,3 +1,10 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 


### PR DESCRIPTION
In reference to rapid7/metasploit-framework#2642, looks like a fatfinger deletion, or a clever attempt to ensure that this PR would actually be read.

Land this and I'll land the result, por favor, @wvu-r7, since @jlee-r7 (rightfully) gets bent out of shape if I tack an extra commit on my merge.
