### PR TITLE
Add rspec for PJL client

### DIFF
--- a/spec/lib/rex/proto/pjl/client_spec.rb
+++ b/spec/lib/rex/proto/pjl/client_spec.rb
@@ -95,7 +95,12 @@ describe Rex::Proto::PJL::Client do
       end
 
       it "should return a LIST directory response" do
-        cli.fsinit("1:")
+        response = "ENTRY=1\r\nDIR\f"
+        tmp_sock = double("sock")
+        tmp_sock.stub(:put).with(an_instance_of(String))
+        tmp_sock.stub(:get).with.and_return(response)
+        tmp_cli = Rex::Proto::PJL::Client.new(tmp_sock)
+        tmp_cli.fsdirlist("1:").should eq('DIR')
       end
     end
 
@@ -105,10 +110,10 @@ describe Rex::Proto::PJL::Client do
       end
 
       it "should return a file" do
-        size_response = "SIZE=1337\r\nFILE\f"
+        response = "SIZE=1337\r\nFILE\f"
         tmp_sock = double("sock")
         tmp_sock.stub(:put).with(an_instance_of(String))
-        tmp_sock.stub(:get).with.and_return(size_response)
+        tmp_sock.stub(:get).with.and_return(response)
         tmp_cli = Rex::Proto::PJL::Client.new(tmp_sock)
         tmp_cli.fsupload("1:").should eq('FILE')
       end


### PR DESCRIPTION
Hi William,

So I see that you're having a hard time with writing the rspec for Rex::Proto::PJL::Client. I understand we all kind of suck at teaching each other how to do this because we're all pretty new to it, but here's my rpsec for your code with 100% coverage. It also serves as an example for you and hopefully this can improve your rspec skills.

Verification steps:
- [x] Run the rspec like this: `rspec spec/lib/rex/proto/pjl/client_spec.rb`
- [x] Confirm that all 15 examples pass the test like the following example:

```
$ rspec spec/lib/rex/proto/pjl/client_spec.rb 
Rex::Proto::PJL::Client ...............

Finished in 1.22 seconds
15 examples, 0 failures
```
