### PR TITLE
Pr4015 disclosure fix

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -168,7 +168,7 @@ class ReadableText
     output << " Privileged: " + (mod.privileged? ? "Yes" : "No") + "\n"
     output << "    License: #{mod.license}\n"
     output << "       Rank: #{mod.rank_to_s.capitalize}\n"
-    output << "  Disclosed: #{mod.disclosure_date}\n"
+    output << "  Disclosed: #{mod.disclosure_date}\n" if mod.disclosure_date
     output << "\n"
 
     # Authors
@@ -224,7 +224,7 @@ class ReadableText
     output << "     Module: #{mod.fullname}\n"
     output << "    License: #{mod.license}\n"
     output << "       Rank: #{mod.rank_to_s.capitalize}\n"
-    output << "  Disclosed: #{mod.disclosure_date}\n"
+    output << "  Disclosed: #{mod.disclosure_date}\n" if mod.disclosure_date
     output << "\n"
 
     # Authors
@@ -270,7 +270,7 @@ class ReadableText
     output << "   Platform: #{mod.platform_to_s}\n"
     output << "       Arch: #{mod.arch_to_s}\n"
     output << "       Rank: #{mod.rank_to_s.capitalize}\n"
-    output << "  Disclosed: #{mod.disclosure_date}\n"
+    output << "  Disclosed: #{mod.disclosure_date}\n" if mod.disclosure_date
     output << "\n"
 
     # Authors


### PR DESCRIPTION
Behold:

```
msf auxiliary(android_stock_browser_uxss) > info exploit/windows/smb/psexec

       Name: Microsoft Windows Authenticated User Code Execution
     Module: exploit/windows/smb/psexec
   Platform: Windows
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Manual
  Disclosed: 1999-01-01

Provided by:
  hdm <hdm@metasploit.com>
```

Versus

```
msf auxiliary(android_stock_browser_uxss) > info auxiliary/scanner/http/http_login 

       Name: HTTP Login Utility
     Module: auxiliary/scanner/http/http_login
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  hdm <hdm@metasploit.com>

```
