### PR TITLE
fix session abort with Ctrl C

### DIFF
--- a/lib/msf/core/session/interactive.rb
+++ b/lib/msf/core/session/interactive.rb
@@ -127,6 +127,7 @@ protected
     rescue Interrupt
       # The user hit ctrl-c while we were handling a ctrl-c. Ignore
     end
+    true
   end
 
   def _usr1


### PR DESCRIPTION
# Before
```
[*] Started reverse TCP handler on 192.168.56.1:4444
[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.1:39426) at 2020-06-29 12:32:42 +0800

^C
Abort session 1? [y/N]  y

```

# After
```
[*] Started reverse TCP handler on 192.168.56.1:4444
[*] Command shell session 1 opened (192.168.56.1:4444 -> 192.168.56.1:40094) at 2020-06-29 12:36:30 +0800

^C
Abort session 1? [y/N]  y

[*] 192.168.56.1 - Command shell session 1 closed.  Reason: User exit
```